### PR TITLE
Use eq's naming for Keys

### DIFF
--- a/encrypter.py
+++ b/encrypter.py
@@ -2,6 +2,7 @@ from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 import base64
 import os
@@ -14,11 +15,20 @@ KID = 'SDE'
 class Encrypter (object):
     def __init__(self):
         private_key_bytes = self._to_bytes(settings.EQ_PRIVATE_KEY)
-        public_key_bytes = self._to_bytes(settings.PUBLIC_KEY)
-
         self.private_key = serialization.load_pem_private_key(private_key_bytes,
                                                               password=self._to_bytes(settings.PRIVATE_KEY_PASSWORD),
                                                               backend=backend)
+
+        private_decryption_key = serialization.load_pem_private_key(
+            settings.PRIVATE_KEY.encode(),
+            password=self._to_bytes(settings.PRIVATE_KEY_PASSWORD),
+            backend=backend
+        )
+
+        public_key_bytes = private_decryption_key.public_key().public_bytes(
+            encoding=Encoding.PEM,
+            format=PublicFormat.SubjectPublicKeyInfo
+        )
 
         self.public_key = serialization.load_pem_public_key(public_key_bytes, backend=backend)
 

--- a/settings.py
+++ b/settings.py
@@ -18,12 +18,11 @@ def get_key(key_name):
 EQ_JWT_LEEWAY_IN_SECONDS = 120
 
 # EQ's keys
-EQ_PUBLIC_KEY = get_key(os.getenv('EQ_PUBLIC_KEY', "/keys/sr-public.pem"))
-EQ_PRIVATE_KEY = get_key(os.getenv('EQ_PRIVATE_KEY', "/keys/sr-private.pem"))
+EQ_PUBLIC_KEY = get_key(os.getenv('EQ_PUBLIC_KEY', "/keys/sdc-submission-signing-sr-public-key.pem"))
+EQ_PRIVATE_KEY = get_key(os.getenv('EQ_PRIVATE_KEY', "/keys/sdc-submission-signing-sr-private-key.pem"))
 
 # Posies keys
-PUBLIC_KEY = get_key(os.getenv('PUBLIC_KEY', "/keys/sdx-public.pem"))
-PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdx-private.pem"))
+PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdc-submission-encryption-sdx-private-key.pem"))
 PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
 
 POSIE_URL = os.getenv('POSIE_URL', 'http://posie:5000')


### PR DESCRIPTION
**Changes**
- Use eq's naming conventions for keys
- Remove dependency on our public key
- Use private key to get public key info

**How to test**
- Boot app in staging/compose environment mounted with latest keys
- Check console starts correctly

**Who can test**
- Anyone but @iwootten
