### PR TITLE
Adding an environment variable for eq key password to fix sdx-console in Pre-prod

### DIFF
--- a/encrypter.py
+++ b/encrypter.py
@@ -16,7 +16,7 @@ class Encrypter (object):
     def __init__(self):
         private_key_bytes = self._to_bytes(settings.EQ_PRIVATE_KEY)
         self.private_key = serialization.load_pem_private_key(private_key_bytes,
-                                                              password=self._to_bytes(settings.PRIVATE_KEY_PASSWORD),
+                                                              password=self._to_bytes(settings.EQ_PRIVATE_KEY_PASSWORD),
                                                               backend=backend)
 
         private_decryption_key = serialization.load_pem_private_key(

--- a/settings.py
+++ b/settings.py
@@ -20,10 +20,12 @@ EQ_JWT_LEEWAY_IN_SECONDS = 120
 # EQ's keys
 EQ_PUBLIC_KEY = get_key(os.getenv('EQ_PUBLIC_KEY', "/keys/sdc-submission-signing-sr-public-key.pem"))
 EQ_PRIVATE_KEY = get_key(os.getenv('EQ_PRIVATE_KEY', "/keys/sdc-submission-signing-sr-private-key.pem"))
+EQ_PRIVATE_KEY_PASSWORD = os.getenv("EQ_PRIVATE_KEY_PASSWORD", "digitaleq")
 
 # Posies keys
 PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdc-submission-encryption-sdx-private-key.pem"))
 PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
+
 
 POSIE_URL = os.getenv('POSIE_URL', 'http://posie:5000')
 


### PR DESCRIPTION
This PR adds an environment variable that contains the eq key password. This will enable us to configure this variable in pre-prod meaning that we should now be able to use sdx-console in pre-prod.

**To test**
Pull down the branch and re-build within docker compose using the `docker-compose build --no-cache` command. Then run `docker-compose up` and in the sdx-console you should be able to run surveys. If you add the following under the 'console' section of the docker-compose.yml file:

`environment:`
       `- EQ_PRIVATE_KEY_PASSWORD=test`

then run `docker-compose up` and try and run a survey you will get an error proving that the environment variable is working.

**Who should test**
Anyone but @howellsaj
