### PR TITLE
Make queue durable in queue_declare

### DIFF
--- a/server.py
+++ b/server.py
@@ -68,7 +68,7 @@ def send_payload(payload, no_of_submissions=1):
 
     channel = connection.channel()
 
-    channel.queue_declare(queue=settings.RABBIT_QUEUE)
+    channel.queue_declare(queue=settings.RABBIT_QUEUE, durable=True)
 
     for i in range(no_of_submissions):
         channel.basic_publish(exchange='',


### PR DESCRIPTION
**Changes**
A recent eQ change has been to make the eQ queue durable, which also needs to be declared on the client side. This pull request adds this setting to the `queue_declare` call.

**How to test**
- Clean sdx-compose build with durable-queue branches for sdx-collect, sdx-console and sdx-bdd
- Run some surveys through the console
- Run sdx-bdd 
- Check the queue is marked as durable in the RabbitMQ UI

**Who can test**
Anyone but @ajmaddaford
