### PR TITLE
Make 'Empty FTP' button configurable

### DIFF
--- a/console/settings.py
+++ b/console/settings.py
@@ -36,6 +36,8 @@ FTP_HOST = os.getenv('FTP_HOST', 'pure-ftpd')
 FTP_USER = os.getenv('FTP_USER')
 FTP_PASS = os.getenv('FTP_PASS')
 
+ENABLE_EMPTY_FTP = os.getenv('ENABLE_EMPTY_FTP', 1)
+
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey')
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(

--- a/console/templates/index.html
+++ b/console/templates/index.html
@@ -85,7 +85,7 @@
             </table>
           </div>
         </div>
-        <button id="empty-ftp" class="btn btn-default">Empty FTP</button>
+        {% if enable_empty_ftp %}<button id="empty-ftp" class="btn btn-default">Empty FTP</button>{% endif %}
     </div>
     <div class="modal fade" id="contentModal" tabindex="-1" role="dialog">
       <div class="modal-dialog modal-lg">

--- a/console/views.py
+++ b/console/views.py
@@ -168,7 +168,8 @@ def submit():
         ftp_data = get_ftp_contents()
         surveys = list_surveys()
 
-        return render_template('index.html', ftp_data=json.dumps(ftp_data),
+        return render_template('index.html', enable_empty_ftp=settings.ENABLE_EMPTY_FTP,
+                               ftp_data=json.dumps(ftp_data),
                                surveys=surveys)
 
 


### PR DESCRIPTION
**Changes**
This change allows us to disable the 'Empty FTP' button on environments like pre-prod where we don't want to accidentally wipe the FTP contents.

**How to test**
- Start the console and check the 'Empty FTP' button appears
- Start the console with the environment variable `ENABLE_EMPTY_FTP=0` and check the 'Empty FTP' button is not visible

**Who can test**
Anyone but @ajmaddaford
