### PR TITLE
configurable logging level

### DIFF
--- a/console/settings.py
+++ b/console/settings.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-console: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
 
 def get_key(key_name):


### PR DESCRIPTION
**Changes**
Enables the logging level to be set by an environment variable

**How to test**
Should work the same by default
Set environment variable to a valid logging level

**Who can test**
Anyone but @elliott-jenkins
