### PR TITLE
Remove ignore installed packages flag from pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /app/
 
 EXPOSE 5000
 
-RUN pip3 install --no-cache-dir -U -I -r /app/requirements.txt
+RUN pip3 install --no-cache-dir -U -r /app/requirements.txt
 
 ENTRYPOINT ./startup.sh


### PR DESCRIPTION
This closes #47 by removing the `-I` flag in the call to `pip install`, which stops pip from trying to reinstall the cryptography package.