### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Log version number on startup, at info level
   - Add configurable log level
   - Add change log
   - Fix [#36](https://github.com/ONSdigital/sdx-console/issues/36) crash/hang when FTP takes too long to respond

--- a/console/__init__.py
+++ b/console/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
 
+__version__ = "1.0.0"
+
 app = Flask(__name__)
 app.config['USE_MLSD'] = True
 

--- a/server.py
+++ b/server.py
@@ -1,6 +1,12 @@
 from console import app
+import logging
 import os
 
+from console import __version__
+
+logger = logging.getLogger(__name__)
+
 if __name__ == '__main__':
+    logger.info("Current version: {}".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/server.py
+++ b/server.py
@@ -7,6 +7,6 @@ from console import __version__
 logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
-    logger.info("Current version: {}".format(__version__))
+    logger.info("Starting server: version='{}'".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
This is a pull request to add functionality that logs the current version number on service startup. The `__version__` variable in `console/__init__.py` contains the variable, which will need to be manually updated on a new release being cut. The version is logged at INFO level.