### PR TITLE
Add missing KID to the encryption meachanism for console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add KID hash to the encrypter
 
 ### 1.5.0 2017-09-14
   - Remove sdx-common git clone in Dockerfile

--- a/console/encrypter.py
+++ b/console/encrypter.py
@@ -27,7 +27,7 @@ class Encrypter (object):
         )
 
         self.signing_kid = Encrypter._generate_kid_from_key(eq_public_key_bytes)
-        logger.error("Signing KID is {}".format(self.signing_kid))
+        logger.info("Signing KID is {}".format(self.signing_kid))
 
         private_decryption_key = serialization.load_pem_private_key(
             settings.PRIVATE_KEY.encode(),
@@ -41,7 +41,7 @@ class Encrypter (object):
         )
 
         self.encryption_kid = Encrypter._generate_kid_from_key(public_key_bytes)
-        logger.error("Encryption KID is {}".format(self.encryption_kid))
+        logger.info("Encryption KID is {}".format(self.encryption_kid))
 
         self.public_key = serialization.load_pem_public_key(public_key_bytes, backend=backend)
 

--- a/console/settings.py
+++ b/console/settings.py
@@ -23,11 +23,9 @@ EQ_JWT_LEEWAY_IN_SECONDS = 120
 # EQ's keys
 EQ_PUBLIC_KEY = get_key(os.getenv('EQ_PUBLIC_KEY', "/keys/sdc-submission-signing-sr-public-key.pem"))
 EQ_PRIVATE_KEY = get_key(os.getenv('EQ_PRIVATE_KEY', "/keys/sdc-submission-signing-sr-private-key.pem"))
-EQ_PRIVATE_KEY_PASSWORD = os.getenv("EQ_PRIVATE_KEY_PASSWORD", "digitaleq")
 
 # Posies keys
 PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdc-submission-encryption-sdx-private-key.pem"))
-PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
 
 SDX_VALIDATE_URL = os.getenv('SDX_VALIDATE_URL', 'http://sdx-validate:5000/validate')
 SDX_STORE_URL = os.getenv('SDX_STORE_URL', 'http://sdx-store:5000/')


### PR DESCRIPTION
## What? and Why?
This should fix the issue using sdx-console with sdx-compose. Basically the new cryptography library required a specific kid to be sent with the JWT and console wasn't do this.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
