### PR TITLE
Fix application crash on invalid tx_id

### DIFF
--- a/CHANGELOGv2.md
+++ b/CHANGELOGv2.md
@@ -31,3 +31,4 @@
   - Improve UX throughout
   - Add submitter functionality
   - Remove sdx-common logging
+  - Add validation on tx_id search to force a valid UUID string to be entered

--- a/console/forms.py
+++ b/console/forms.py
@@ -25,6 +25,7 @@ class NewUserForm(Form):
             msg = '{} should have atleast one number'.format(field.name)
             raise ValidationError(msg)
 
+
 class StoreForm(Form):
     tx_id = StringField('tx_id', validators=[
         Length(max=36),

--- a/console/forms.py
+++ b/console/forms.py
@@ -2,7 +2,7 @@ import re
 
 from flask_wtf import Form
 from wtforms import StringField, PasswordField
-from wtforms.validators import DataRequired, Length, ValidationError
+from wtforms.validators import DataRequired, Length, ValidationError, Regexp
 
 
 class NewUserForm(Form):
@@ -24,3 +24,10 @@ class NewUserForm(Form):
         if not re.findall('.*[0-9].*', data):
             msg = '{} should have atleast one number'.format(field.name)
             raise ValidationError(msg)
+
+class StoreForm(Form):
+    tx_id = StringField('tx_id', validators=[
+        Length(max=36),
+        Regexp('^[0-9a-f\-]{36}$|^$', message="Field can only contain hexadecimal characters (0-9a-f) and dash (-)"),
+        Regexp('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|^$', message="Field must be in the form {8}-{4}-{4}-{4}-{12}"),
+    ])

--- a/console/templates/store.html
+++ b/console/templates/store.html
@@ -20,7 +20,7 @@
           <input type="radio" name="valid" value="invalid"> Invalid <br> <br>
 
           <label class="col-md-1 control-label" for="tx_id">tx_id:</label> <br>
-          <input type="text" class="form-control" id="tx_id" name="tx_id"> <br>
+          {{ form.tx_id }}<br>
 
           <label class="col-md-1 control-label" for="ru_ref">ru_ref:</label> <br>
           <input type="text" class="form-control" id="ru_ref" name="ru_ref"> <br>
@@ -38,6 +38,13 @@
         <span class="input-group-btn">
             <button class="btn btn-default" type="submit">Search</button>
         </span>
+        {% if form.errors %}
+            <ul class=errors>
+            {% for error in form.errors %}
+              <li>{{error}} : {{ form.errors[error][0] }}</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
       </div>
     </div>
   </form>

--- a/console/views/store.py
+++ b/console/views/store.py
@@ -14,6 +14,7 @@ from structlog import wrap_logger
 
 from console import settings
 from console.database import db_session
+from console.forms import StoreForm
 from console.models import SurveyResponse
 from console.views.home import send_data
 from sdc.rabbit import QueuePublisher
@@ -99,8 +100,14 @@ def store(page):
     datetime_earliest = request.args.get('datetime_earliest', type=str, default='')
     datetime_latest = request.args.get('datetime_latest', type=str, default='')
 
-    store_data = get_filtered_responses(
-        audited_logger, valid, tx_id, ru_ref, survey_id, datetime_earliest, datetime_latest)
+    form = StoreForm(tx_id=tx_id)
+    if form.validate():
+        store_data = get_filtered_responses(
+            audited_logger, valid, tx_id, ru_ref, survey_id, datetime_earliest, datetime_latest)
+    else:
+        # If validation unsuccessful, pretend it was an empty search to give user
+        # more than an empty results table to look at
+        store_data = get_filtered_responses(audited_logger, '', '', '', '', '', '')
 
     audited_logger.info("Successfully retrieved responses")
 
@@ -112,7 +119,8 @@ def store(page):
                            data=json_list,
                            no_pages=no_pages,
                            page=int(page),
-                           current_user=flask_security.core.current_user)
+                           current_user=flask_security.core.current_user,
+                           form=form)
 
 
 @store_bp.route('/storetest', strict_slashes=False, methods=['GET'])


### PR DESCRIPTION
## What? and Why?
The application was crashing whenever an incorrect tx_id was being passed in.

It was unclear at first but this was being caused by an invalid uuid being passed in.  UUID has a precise specification
in RFC 4122, this validation makes it follow one of the valid forms of UUID.  The validation
could be expanded in future if we have UUIDs in different forms, but currently we only
use the one.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
