### PR TITLE
Update tx_id validation to use a more standard way

### DIFF
--- a/console/forms.py
+++ b/console/forms.py
@@ -1,8 +1,9 @@
 import re
+import uuid
 
 from flask_wtf import Form
 from wtforms import StringField, PasswordField
-from wtforms.validators import DataRequired, Length, ValidationError, Regexp
+from wtforms.validators import DataRequired, Length, ValidationError
 
 
 class NewUserForm(Form):
@@ -27,8 +28,18 @@ class NewUserForm(Form):
 
 
 class StoreForm(Form):
-    tx_id = StringField('tx_id', validators=[
-        Length(max=36),
-        Regexp('^[0-9a-f\-]{36}$|^$', message="Field can only contain hexadecimal characters (0-9a-f) and dash (-)"),
-        Regexp('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|^$', message="Field must be in the form {8}-{4}-{4}-{4}-{12}"),
-    ])
+    tx_id = StringField('tx_id')
+    ru_ref = StringField('ru_ref')
+    survey_id = StringField('survey_id')
+
+    @staticmethod
+    def validate_tx_id(form, field):
+        data = field.data
+
+        # First if handles the empty string.  Using the UUID() and Optional() rules
+        # were attempted but we couldn't get it to work so this is a workaround.
+        if data:
+            try:
+                uuid.UUID(field.data)
+            except ValueError:
+                raise ValidationError('Invalid UUID.')

--- a/console/templates/store.html
+++ b/console/templates/store.html
@@ -23,10 +23,10 @@
           {{ form.tx_id }}<br>
 
           <label class="col-md-1 control-label" for="ru_ref">ru_ref:</label> <br>
-          <input type="text" class="form-control" id="ru_ref" name="ru_ref"> <br>
+          {{ form.ru_ref }}<br>
 
           <label class="col-md-1 control-label" for="survey_id">survey_id:</label> <br>
-          <input type="number" class="form-control" id="survey_id" name="survey_id"> <br> <br>
+          {{ form.survey_id }}<br> <br>
 
           <label class="col-md-1 control-label" for="datetime_earliest">datetime_earliest: </label>
           <input type="datetime-local" class="form-control" id="datetime_earliest" name="datetime_earliest"> <br>

--- a/console/views/store.py
+++ b/console/views/store.py
@@ -110,9 +110,7 @@ def store(page):
         store_data = get_filtered_responses(
             audited_logger, valid, tx_id, ru_ref, survey_id, datetime_earliest, datetime_latest)
     else:
-        # If validation unsuccessful, pretend it was an empty search to give user
-        # more than an empty results table to look at
-        store_data = get_filtered_responses(audited_logger, '', '', '', '', '', '')
+        store_data = []
 
     audited_logger.info("Successfully retrieved responses")
 

--- a/console/views/store.py
+++ b/console/views/store.py
@@ -100,7 +100,12 @@ def store(page):
     datetime_earliest = request.args.get('datetime_earliest', type=str, default='')
     datetime_latest = request.args.get('datetime_latest', type=str, default='')
 
-    form = StoreForm(tx_id=tx_id)
+    form = StoreForm(
+        tx_id=tx_id,
+        ru_ref=ru_ref,
+        survey_id=survey_id
+    )
+
     if form.validate():
         store_data = get_filtered_responses(
             audited_logger, valid, tx_id, ru_ref, survey_id, datetime_earliest, datetime_latest)


### PR DESCRIPTION
The way the tx_id is now validated is identical to the UUID() rule that
is in wtforms.  The reason we're not using it is because it threw an error on the empty
string, and adding optional() for some reason didn't validate it when the string wasn't empty
(leading to crashes again).

The fields in the StoreForm were added so that on the search results being returned, it now
doesn't clear down the tx_id, ru_ref and survey_id fields (making for a slightly better user
experience).

## What? and Why?
> What does this pull request change/fix? Why was it necessary?

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
