### PR TITLE
Remove unused gunicorn from startup script

### DIFF
--- a/CHANGELOGv2.md
+++ b/CHANGELOGv2.md
@@ -32,4 +32,3 @@
   - Add submitter functionality
   - Remove sdx-common logging
   - Add validation on tx_id search to force a valid UUID string to be entered
-  - Add https support for prod and preprod

--- a/CHANGELOGv2.md
+++ b/CHANGELOGv2.md
@@ -32,3 +32,4 @@
   - Add submitter functionality
   - Remove sdx-common logging
   - Add validation on tx_id search to force a valid UUID string to be entered
+  - Add https support for prod and preprod

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,6 @@ COPY Makefile /app/Makefile
 WORKDIR /app/
 
 EXPOSE 4200
-
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -yq git gcc make build-essential python3-dev python3-reportlab
 RUN make build
 
 ENTRYPOINT ./startup.sh

--- a/startup.sh
+++ b/startup.sh
@@ -1,13 +1,2 @@
 #!/bin/bash
-
-if [ -z ${PORT+x} ];
-then
-    export PORT=5000;
-fi
-
-if [ "$SDX_DEV_MODE" = true ]
-then
-    python3 server.py
-else
-    gunicorn --certfile $SDX_CONSOLE_SSL_CERTIFICATE --keyfile $SDX_CONSOLE_SSL_KEY -b 0.0.0.0:$PORT server:app
-fi
+python3 server.py

--- a/startup.sh
+++ b/startup.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ -z ${PORT+x} ]; 
-then 
-    export PORT=5000; 
+if [ -z ${PORT+x} ];
+then
+    export PORT=5000;
 fi
 
 if [ "$SDX_DEV_MODE" = true ]
 then
     python3 server.py
 else
-    gunicorn -b 0.0.0.0:$PORT server:app
+    gunicorn --certfile $SDX_CONSOLE_SSL_CERTIFICATE --keyfile $SDX_CONSOLE_SSL_KEY -b 0.0.0.0:$PORT server:app
 fi


### PR DESCRIPTION
## What? and Why?
This is being removed because the gunicorn command that is used in prod and preprod comes from another place and not the startup script.  Removing it will reduce confusion in the future.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
