### PR TITLE
In memory files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - Add submitter functionality
   - Remove sdx-common logging
   - Add validation on tx_id search to force a valid UUID string to be entered
+  - FTP files write to memory instead of writing temporary files
 
 ### 1.7.0 2017-11-30
   - Deploying new console

--- a/console/console_ftp.py
+++ b/console/console_ftp.py
@@ -76,6 +76,6 @@ class ConsoleFtp(object):
 
     def get_file_contents(self, datatype, filename):
         ftp_file = BytesIO()
-        self._ftp.retrbinary("RETR " + PATHS[datatype] + "/" + filename, ftp_file.write())
+        self._ftp.retrbinary("RETR " + PATHS[datatype] + "/" + filename, ftp_file.write)
         ftp_file.seek(0)
         return ftp_file.read().decode("utf-8")

--- a/console/console_ftp.py
+++ b/console/console_ftp.py
@@ -74,8 +74,12 @@ class ConsoleFtp(object):
         file_list.sort(key=operator.itemgetter('modify'), reverse=True)
         return file_list
 
+    """ Searches for a file in the FTP server and returns it in binary
+    format.  It's up to the function calling this one to convert the output
+    into a more useful format.
+    """
     def get_file_contents(self, datatype, filename):
         ftp_file = BytesIO()
         self._ftp.retrbinary("RETR " + PATHS[datatype] + "/" + filename, ftp_file.write)
         ftp_file.seek(0)
-        return ftp_file.read().decode("utf-8")
+        return ftp_file.read()

--- a/console/console_ftp.py
+++ b/console/console_ftp.py
@@ -1,4 +1,5 @@
 from console import app
+from io import BytesIO
 import logging
 
 import operator
@@ -74,6 +75,7 @@ class ConsoleFtp(object):
         return file_list
 
     def get_file_contents(self, datatype, filename):
-        self._ftp.retrbinary("RETR " + PATHS[datatype] + "/" + filename, open('tmpfile', 'wb').write)
-        transferred = open('tmpfile', 'r')
-        return transferred.read()
+        ftp_file = BytesIO()
+        self._ftp.retrbinary("RETR " + PATHS[datatype] + "/" + filename, ftp_file.write())
+        ftp_file.seek(0)
+        return ftp_file.read().decode("utf-8")

--- a/console/views/FTP.py
+++ b/console/views/FTP.py
@@ -36,15 +36,6 @@ def mod_to_iso(file_modified):
     t = datetime.strptime(file_modified, '%Y%m%d%H%M%S')
     return t.isoformat()
 
-
-def get_image(filename):
-    ftp_file = BytesIO()
-    with ConsoleFtp() as ftp:
-        ftp._ftp.retrbinary("RETR " + PATHS['image'] + "/" + filename, ftp_file.write)
-    ftp_file.seek(0)
-    return base64.b64encode(ftp_file.read()).decode()
-
-
 def get_file_contents(datatype, filename):
     with ConsoleFtp() as ftp:
         return ftp.get_file_contents(datatype, filename)
@@ -65,9 +56,10 @@ def ftp_list():
 def view_file(datatype, filename):
     if filename.lower().endswith(('jpg', 'png')):
         extension = filename.split(".")[-1]
-        return '<img style="width:100%;" src="data:image/' + extension + ';base64,' + get_image(filename) + '" />'
+        b64_image = base64.b64encode(get_file_contents(datatype, filename)).decode()
+        return '<img style="width:100%;" src="data:image/' + extension + ';base64,' + b64_image + '" />'
     else:
-        return '<pre>' + get_file_contents(datatype, filename) + '</pre>'
+        return '<pre>' + get_file_contents(datatype, filename).decode("utf-8") + '</pre>'
 
 
 @FTP_bp.route('/clear')

--- a/console/views/FTP.py
+++ b/console/views/FTP.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from io import BytesIO
 import base64
 import json
 import logging.handlers
@@ -35,6 +34,7 @@ def get_ftp_contents():
 def mod_to_iso(file_modified):
     t = datetime.strptime(file_modified, '%Y%m%d%H%M%S')
     return t.isoformat()
+
 
 def get_file_contents(datatype, filename):
     with ConsoleFtp() as ftp:


### PR DESCRIPTION
## What? and Why?
Console FTP tab wasn't working because in order to view files, temporary files needed to be written; But the permissions on the filesystem wouldn't let it.  The new way writes these files to memory as the temporary step, then does whatever it needs to.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
