### PR TITLE
Change unit tests to in memory database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   - Remove /clear endpoint
   - Use pytest and codecov
   - Add tests to travis build
+  - Updated unit tests to use an in memory database
 
 
 ### 1.7.0 2017-11-30

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import testing.postgresql
+import console.settings
+
+Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=False)
+postgresql = Postgresql()
+console.settings.DB_URI = postgresql.url()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,0 @@
-import testing.postgresql
-import console.settings
-
-Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=False)
-postgresql = Postgresql()
-console.settings.DB_URI = postgresql.url()

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -15,6 +15,7 @@ from console.models import SurveyResponse, create_initial_users
 import console.settings
 import server
 
+
 Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=False)
 
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -6,6 +6,7 @@ from unittest import mock
 import requests
 import testing.postgresql
 
+import console.settings
 import server
 from console import app
 from console import db
@@ -13,6 +14,11 @@ from console import logger
 from console import views
 from console.helpers.exceptions import ClientError, ServiceError
 from console.models import SurveyResponse, create_initial_users
+
+# Generate temporary database
+Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=False)
+postgresql = Postgresql()
+console.settings.DB_URI = postgresql.url()
 
 
 class TestConsole(unittest.TestCase):
@@ -92,9 +98,8 @@ class TestAuthentication(unittest.TestCase):
             db.session.commit()
 
     def tearDown(self):
-        with app.app_context():
-            db.session.remove()
-            db.drop_all()
+        Postgresql.clear_cache()
+        postgresql.stop()
 
     def login(self, email, password):
         return self.app.post('/login', data={'email': email, 'password': password})
@@ -161,9 +166,8 @@ class TestStore(unittest.TestCase):
         submit_test_responses()
 
     def tearDown(self):
-        with app.app_context():
-            db.session.remove()
-            db.drop_all()
+        Postgresql.clear_cache()
+        postgresql.stop()
 
     def test_display_data(self):
         response = self.app.get('/store', follow_redirects=True)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -12,7 +12,7 @@ from console import db
 from console import logger
 from console import views
 from console.helpers.exceptions import ClientError, ServiceError
-from console.models import SurveyResponse
+from console.models import SurveyResponse, create_initial_users
 
 
 class TestConsole(unittest.TestCase):
@@ -55,9 +55,6 @@ class TestConsole(unittest.TestCase):
                 views.submit.send_data(logger, "", data=123)
 
 
-Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=False)
-
-
 def get_test_data():
     site_root = os.path.realpath(os.path.dirname(__file__))
     json_url = os.path.join(site_root, 'test_data', 'test_response_1.json')
@@ -81,18 +78,23 @@ def submit_test_responses():
             db.session.commit()
 
 
+@testing.postgresql.skipIfNotInstalled
 class TestAuthentication(unittest.TestCase):
 
     def setUp(self):
-        self.postgres = Postgresql()
-        Postgresql.clear_cache()
         self.app = server.app.test_client()
         self.app.testing = True
         self.render_templates = False
 
+        with app.app_context():
+            db.create_all()
+            create_initial_users()
+            db.session.commit()
+
     def tearDown(self):
-        Postgresql.clear_cache()
-        self.postgres.stop()
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
     def login(self, email, password):
         return self.app.post('/login', data={'email': email, 'password': password})
@@ -142,20 +144,26 @@ class TestAuthentication(unittest.TestCase):
         self.assertIn(b'Please log in to access this page.', response.data)
 
 
+@testing.postgresql.skipIfNotInstalled
 class TestStore(unittest.TestCase):
 
     def setUp(self):
-        self.postgres = Postgresql()
-        Postgresql.clear_cache()
         self.app = server.app.test_client()
         self.app.testing = True
         self.render_templates = False
+
+        with app.app_context():
+            db.create_all()
+            create_initial_users()
+            db.session.commit()
+
         TestAuthentication.login(self, 'admin', 'admin')
         submit_test_responses()
 
     def tearDown(self):
-        Postgresql.clear_cache()
-        self.postgres.stop()
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
     def test_display_data(self):
         response = self.app.get('/store', follow_redirects=True)


### PR DESCRIPTION
## What? and Why?
> Updated unit tests to use an in memory database, previously the tests were creating a database in memory but then defaulting back to using the on disk database from the default settings.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
