### PR TITLE
Fix tab URLs for /submit and /store

### DIFF
--- a/console/templates/partials/navigation_tabs.html
+++ b/console/templates/partials/navigation_tabs.html
@@ -6,7 +6,7 @@
        <a href="/submit"
           class="btn btn--secondary navigation-tabs__tab"> Submit </a>
       {% else %}
-       <a href="submit"
+       <a href="/submit"
           class="btn btn--secondary btn--border navigation-tabs__tab"> Submit </a>
       {% endif %}
   </li>
@@ -17,7 +17,7 @@
         <a href="/store"
            class="btn btn--secondary navigation-tabs__tab"> Store </a>
       {% else %}
-        <a href="store"
+        <a href="/store"
            class="btn btn--secondary btn--border navigation-tabs__tab"> Store </a>
       {% endif %}
   </li>


### PR DESCRIPTION
Fix tab URLs for /submit and /store which weren't working when on a nested page e.g. /store/page.
