### PR TITLE
Remove second rabbit url host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   - Use pytest and codecov
   - Add tests to travis build
   - Updated unit tests to use an in memory database
+  - Remove second rabbit host for aws
 
 
 ### 1.7.0 2017-11-30

--- a/console/settings.py
+++ b/console/settings.py
@@ -72,12 +72,4 @@ else:
         vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
     )
 
-    RABBIT_URL2 = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
-        hostname=os.getenv('RABBITMQ_HOST2', 'rabbit'),
-        port=os.getenv('RABBITMQ_PORT2', 5672),
-        user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
-        password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
-        vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
-    )
-
-RABBIT_URLS = [RABBIT_URL, RABBIT_URL2]
+RABBIT_URLS = [RABBIT_URL]


### PR DESCRIPTION
## What? and Why?
Remove the second rabbit host url in preparation of the move to AWS corp where there is a load balance in front of the rabbit cluster

## Checklist
  - [x] CHANGELOG.md updated? (if required)
