### PR TITLE
Add feedback response to examples

### DIFF
--- a/console/static/surveys/lms.feedback.json
+++ b/console/static/surveys/lms.feedback.json
@@ -1,0 +1,23 @@
+{
+    "data": {
+        "url": "https://eq.ons.gov.uk/questionnaire/lms/2/3c5b8eb9-17e9-493e-a5d4-d4eacee79309/household-member-group/0/paid-job-q1",
+        "name": "Another Person",
+        "email": "a.person@email.com",
+        "message": "I think this page is quite good"
+    },
+    "type": "uk.gov.ons.edc.eq:feedback",
+    "tx_id": "7c3dda82-a274-40dd-84f1-7ed08b7a917e",
+    "origin": "uk.gov.ons.edc.eq",
+    "version": "0.0.1",
+    "metadata": {
+        "ru_ref": "ABC123456",
+        "user_id": "a7b481f5-be36-484b-b7e5-61a2d90f10ee"
+    },
+    "survey_id": "lms",
+    "collection": {
+        "period": "2",
+        "exercise_sid": "3c5b8eb9-17e9-493e-a5d4-d4eacee79309",
+        "instrument_id": "2"
+    },
+    "submitted_at": "2018-10-27T10:12:14.257090"
+}

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -29,6 +29,7 @@ class TestConsoleSubmit(unittest.TestCase):
             "144.0001.json",
             "lms.1.json",
             "lms.2.json",
+            "lms.feedback.json",
         ]
 
         self.assertEqual(surveys, response)


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/fqqVuRhm/2549-stop-lms-feedback-surveys

Adds a feedback survey to the example submissions to make testing that functionality easier

## Checklist
  - [x] CHANGELOG.md updated? (if required)
