### PR TITLE
Added change to NI UKIS to test elements 0440 and 2671

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - modified 144.0002 data (UKIS NI) to have elements 0440 and 2671
   - Log version number on startup, at info level
   - Add configurable log level
   - Add change log

--- a/console/static/surveys/144.0002.json
+++ b/console/static/surveys/144.0002.json
@@ -8,6 +8,7 @@
 	"data": {
 		"0210": "UK regional within approximately 100 miles of this business",
 		"0220": "UK National",
+		"0440": "No significant changes occurred",
 		"0510": "Yes",
 		"0520": "Yes",
 		"0601": "This business or enterprise group",
@@ -96,7 +97,7 @@
 		"2665": "Not important",
 		"2666": "Medium importance",
 		"2667": "Low importance",
-		"2668": "UK local or regional authorities",
+		"2671": "No public financial support was received for innovation activities from government",
 		"2675": "2016",
 		"2676": "2017",
 		"2700": "words",


### PR DESCRIPTION
## What? and Why?
UKIS has two surveys 144.0001 and 0002 , where 2 is for NI. This modified the test data in the NI one to add values for the new elements 0440 and 2671

## Checklist
 CHANGELOG.md updated 
