### PR TITLE
Add missing metadata to submissions

### DIFF
--- a/console/static/surveys/009.0167.json
+++ b/console/static/surveys/009.0167.json
@@ -19,8 +19,8 @@
     "flushed": false,
     "metadata": {
         "ref_period_end_date": "2016-05-31",
-        "ru_ref": "49900108249D",
         "ref_period_start_date": "2016-05-01",
+        "ru_ref": "49900108249D",
         "user_id": "UNKNOWN"
     },
     "origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0001.json
+++ b/console/static/surveys/017.0001.json
@@ -19,7 +19,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "15162882666f",
+		"ref_period_end_date": "2018-11-29",
+		"ref_period_start_date": "2019-04-01",
+		"ru_ref": "15162882666F",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0005.json
+++ b/console/static/surveys/017.0005.json
@@ -25,7 +25,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "15162882666f",
+		"ref_period_end_date": "2018-11-29",
+		"ref_period_start_date": "2019-04-01",
+		"ru_ref": "15162882666F",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0011.json
+++ b/console/static/surveys/017.0011.json
@@ -18,7 +18,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "15162882666f",
+		"ref_period_end_date": "2018-11-29",
+		"ref_period_start_date": "2019-04-01",
+		"ru_ref": "15162882666F",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0012.json
+++ b/console/static/surveys/017.0012.json
@@ -17,7 +17,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "25462342626b",
+		"ref_period_end_date": "2019-01-02",
+		"ref_period_start_date": "2019-04-01",
+		"ru_ref": "25462342626B",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0051.json
+++ b/console/static/surveys/017.0051.json
@@ -18,7 +18,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "25462342626b",
+		"ref_period_end_date": "201-10-29",
+		"ref_period_start_date": "2019-03-01",
+		"ru_ref": "25462342626B",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",

--- a/console/static/surveys/017.0052.json
+++ b/console/static/surveys/017.0052.json
@@ -15,7 +15,9 @@
 	},
 	"flushed": false,
 	"metadata": {
-		"ru_ref": "25463341690b",
+		"ref_period_end_date": "2019-02-01",
+		"ref_period_start_date": "2019-04-30",
+		"ru_ref": "25463341690B",
 		"user_id": "UNKNOWN"
 	},
 	"origin": "uk.gov.ons.edc.eq",


### PR DESCRIPTION
## What? and Why?
A recent change to the stocks submission transformation highlighted that there was missing date metadata in the example submissions for stocks.

## How to test
Attempt to submit one of the survey_id 17 submissions that doesn't explictly sent qcode 11 and 12 (with all branches on master).  It should log out that there is missing metadata
Submit one of the fixed submissions, should transform successfully because all the required metadata is present


## Checklist
  - [x] CHANGELOG.md updated? (if required)
