### PR TITLE
Update travis build to include python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+    - "3.8"
     - "3.7"
     - "3.6"
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add python 3.8 to travis build
   - Update sdc-cryptography to 0.4.0
   - Update sdc-rabbit to 1.7.0 to fix reconnection issues
   - Update various other dependencies


### PR DESCRIPTION
## What? and Why?
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use

## Checklist
  - [x] CHANGELOG.md updated? (if required)
